### PR TITLE
Fix missing Estimate on Slider

### DIFF
--- a/electrum/gui/qt/fee_slider.py
+++ b/electrum/gui/qt/fee_slider.py
@@ -61,7 +61,7 @@ class FeeSlider(QSlider):
         if self.dyn:
             return _('Target') + ': ' + target + '\n' + _('Current rate') + ': ' + estimate
         else:
-            return _('Fixed rate') + ': ' + target + '\n' + _('Estimate') + ': ' + estimate
+            return _('Fixed rate') + ': ' + target + '\n' + _('Estimate') + ': ' + _('In the next block')
 
     def get_dynfee_target(self):
         if not self.dyn:


### PR DESCRIPTION
This commit returns the correct block estimate value which is always "In the next block" on our network.